### PR TITLE
[30기 전슬기] Add: Nav, Footer 컴포넌트 & common.scss 수정

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,5 +1,67 @@
+import { Link } from 'react-router-dom';
+import './Footer.scss';
+
 function Footer() {
-  return <div />;
+  return (
+    <footer className="Footer">
+      <div className="footerColumn">
+        <div className="footerRow">
+          <div className="snsIcon">
+            <img
+              alt="인스타 아이콘"
+              className="snsLogo"
+              src="img/sophie/cakoo_facebook_logo_white.png"
+            />
+            <img
+              alt="인스타 아이콘"
+              className="snsLogo"
+              src="img/sophie/cakoo_insta_logo_white.png"
+            />
+            <img
+              alt="인스타 아이콘"
+              className="snsLogo"
+              src="img/sophie/cakoo_youtube_logo_white.png"
+            />
+          </div>
+          <p className="callcenter">
+            <span className="bigFont">케이쿠 고객센터 1997-1122 </span>
+            <span className="smallFont">
+              (평일 10:00-13:00, 14:00-18:00 / 주말 & 공휴일 제외)
+            </span>
+            <button className="callcenterBtn">꾸까 고객센터 ></button>
+          </p>
+        </div>
+        <Link to="/">
+          <img
+            alt="cakoo 로고 화이트"
+            className="logo"
+            src="img/sophie/cakoo_logo_white.png"
+          />
+        </Link>
+      </div>
+
+      <hr />
+
+      <div className="footerColumn footerBottom">
+        <div>
+          <p>
+            상호명: 케이쿠(cakoo) | 사업자 등록번호: 123-45-67890 | 대표자:
+            위코드
+          </p>
+          <p>
+            소재지: 서울시 강남구 테헤란로 10 cakoo | 기업공시 |
+            통신판매신고번호 2022-서울위코드-0311
+          </p>
+          <p>© 2022 cakoo, inc. All rights reserved.</p>
+        </div>
+        <p>
+          <span>이용약관</span>
+          <span className="margin">개인정보 처리방침</span>
+          <span className="margin">제휴안내</span>
+        </p>
+      </div>
+    </footer>
+  );
 }
 
 export default Footer;

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -3,7 +3,7 @@ import './Footer.scss';
 
 function Footer() {
   return (
-    <footer className="Footer">
+    <footer className="footer">
       <div className="footerColumn">
         <div className="footerRow">
           <div className="snsIcon">

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,0 +1,72 @@
+@import '/src/styles/variables.scss';
+
+.Footer {
+  padding: 80px 160px;
+  background-color: $black;
+  color: white;
+
+  p {
+    line-height: 160%;
+  }
+
+  .footerColumn {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+
+    .footerRow {
+      .snsIcon {
+        margin-bottom: 10px;
+
+        .snsLogo {
+          width: 35px;
+          margin-right: 20px;
+        }
+      }
+
+      .callcenter {
+        display: flex;
+        align-items: center;
+
+        .bigFont {
+          font-size: 22px;
+          font-weight: 700;
+        }
+
+        .smallFont {
+          margin-left: 10px;
+          font-size: 14px;
+          color: gray;
+        }
+
+        .callcenterBtn {
+          padding: 10px 18px;
+          margin-left: 15px;
+          border: 1px solid white;
+          border-radius: 20px;
+          color: white;
+          background: none;
+        }
+      }
+    }
+
+    .logo {
+      width: 65px;
+    }
+  }
+
+  hr {
+    margin: 20px 0;
+    border: 0;
+    height: 1px;
+    background: gray;
+  }
+
+  .footerBottom {
+    font-size: 14px;
+
+    .margin {
+      margin-left: 25px;
+    }
+  }
+}

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,6 +1,6 @@
 @import '/src/styles/variables.scss';
 
-.Footer {
+.footer {
   padding: 80px 160px;
   background-color: $black;
   color: white;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,5 +1,29 @@
+import { Link } from 'react-router-dom';
+import './Nav.scss';
+
 function Nav() {
-  return <div />;
+  return (
+    <nav className="Nav">
+      <Link to="/">
+        <img
+          alt="cakoo 로고"
+          className="logo"
+          src="img/sophie/cakoo_logo.png"
+        />
+      </Link>
+      <ul className="navUser">
+        <li>
+          <Link to="/login">로그인</Link>
+        </li>
+        <li>
+          <Link to="/sign-up">회원가입</Link>
+        </li>
+        <li>
+          <Link to="/cart">장바구니</Link>
+        </li>
+      </ul>
+    </nav>
+  );
 }
 
 export default Nav;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -3,7 +3,7 @@ import './Nav.scss';
 
 function Nav() {
   return (
-    <nav className="Nav">
+    <nav className="nav">
       <Link to="/">
         <img
           alt="cakoo 로고"

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -1,6 +1,6 @@
 @import '/src/styles/variables.scss';
 
-.Nav {
+.nav {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -1,0 +1,46 @@
+@import '/src/styles/variables.scss';
+
+.Nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 85px;
+  padding: 0 160px;
+  background-color: #fefeff;
+  border-bottom: 1px solid $yellow;
+
+  .logo {
+    width: 45px;
+  }
+
+  .navUser {
+    display: flex;
+    align-items: center;
+
+    li {
+      display: flex;
+      align-items: center;
+    }
+
+    li::before {
+      content: '';
+      display: block;
+      width: 1px;
+      height: 18px;
+      margin-left: 12px;
+      background-color: #d2d2d3;
+    }
+
+    li:first-child::before {
+      content: none;
+    }
+
+    a {
+      margin-left: 12px;
+      font-size: 14px;
+    }
+  }
+}

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,3 +1,4 @@
+@import '/src/styles/variables.scss';
 @import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700&display=swap');
 
 * {
@@ -5,9 +6,21 @@
 
   body {
     font-family: 'Nanum Gothic', sans-serif;
+    background-color: #fefeff;
+    color: $black;
+
+    p {
+      line-height: normal;
+    }
 
     a {
       text-decoration: none;
+      color: $black;
+    }
+
+    a:hover,
+    button:hover {
+      cursor: pointer;
     }
 
     button {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 공통 컴포넌트인 Nav와 Footer를 만들고, 공통 styles를 수정함.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Nav 컴포넌트
- 클릭하면 연결된 각 페이지로 이동하는 로고와 로그인/회원가입/장바구니 버튼.
- 스크롤을 내려도 상단에 고정되어있음.
2. Footer 컴포넌트
- 버튼이 하나 포함돼있어서 hover 시 커서가 pointer로 바뀌게 설정.
- (하지만 페이지 이동 기능은 필요 없어서 작동하지 않음.)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 아직 해결하진 못했지만, Nav와 본문의 컨텐츠들이 일정한 좌우 여백을 두고 있는데 그 사이의 배너는 여백 없이 너비를 모두 차지하고 있어서 어떻게 하면 좋을지 고민해보고 있습니다. 브라우저의 크기에 따라 이 여백이 함께 달라지는 점도 고민입니다.

<br />

## :: 기타 질문 및 특이 사항
- 팀원들과 공통 파일 변경 사항공유할 수 있도록 merge 부탁드립니다!!
